### PR TITLE
Create Survey Api

### DIFF
--- a/dotnetcorehack.Test/Controllers/QuestionsControllerTest..cs
+++ b/dotnetcorehack.Test/Controllers/QuestionsControllerTest..cs
@@ -29,9 +29,15 @@ namespace Dotnetcorehack.Test.Controllers
             this.questionsController = new QuestionsController(this.questionRepository.Object);
         }
 
-        private string AnyString()
+        [Fact]
+        public void ShouldDefineTheRoute()
         {
-            return Guid.NewGuid().ToString();
+            var routeAttribute = typeof(QuestionsController).GetTypeInfo().GetCustomAttributes(typeof(RouteAttribute), true)
+                .Cast<RouteAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "/[controller]");
         }
 
         public class GetTest : QuestionsControllerTest
@@ -54,6 +60,19 @@ namespace Dotnetcorehack.Test.Controllers
 
                 Assert.IsType<NotFoundResult>(response);
             }
+
+            [Fact]
+            public void ShouldBeAHttpGet()
+            {
+                var methodInfo = typeof(QuestionsController).GetMethod(nameof(this.questionsController.Get));
+
+                var getAttribute = methodInfo.GetCustomAttributes(typeof(HttpGetAttribute), true)
+                .Cast<HttpGetAttribute>()
+                .FirstOrDefault();
+
+                Assert.NotNull(getAttribute);
+                Assert.Equal(getAttribute.Template, "{id}");
+            }
         }
 
         public class PostTest : QuestionsControllerTest
@@ -71,6 +90,18 @@ namespace Dotnetcorehack.Test.Controllers
 
                 Assert.Equal(actualResponse.Location, "/questions/" + expectedQuestionCreated.Id);
                 Assert.Same(expectedQuestionCreated, actualResponse.Value);
+            }
+
+            [Fact]
+            public void ShouldBeAHttpPost()
+            {
+                var methodInfo = typeof(QuestionsController).GetMethod(nameof(this.questionsController.Post));
+
+                var postAttribute = methodInfo.GetCustomAttributes(typeof(HttpPostAttribute), true)
+                .Cast<HttpPostAttribute>()
+                .FirstOrDefault();
+
+                Assert.NotNull(postAttribute);
             }
         }
 
@@ -95,6 +126,19 @@ namespace Dotnetcorehack.Test.Controllers
 
                 Assert.IsType<NotFoundResult>(actualResponse);
             }
+
+            [Fact]
+            public void ShouldBeAHttpPut()
+            {
+                var methodInfo = typeof(QuestionsController).GetMethod(nameof(this.questionsController.Put));
+
+                var putAttribute = methodInfo.GetCustomAttributes(typeof(HttpPutAttribute), true)
+                .Cast<HttpPutAttribute>()
+                .FirstOrDefault();
+
+                Assert.NotNull(putAttribute);
+                Assert.Equal(putAttribute.Template, "{id}");
+            }
         }
 
         public class DeleteTest : QuestionsControllerTest
@@ -107,6 +151,19 @@ namespace Dotnetcorehack.Test.Controllers
                 this.questionRepository.Verify(repo => repo.DeleteQuestion(this.expectedId), Times.Once);
 
                 Assert.IsType<NoContentResult>(actualResponse);
+            }
+
+            [Fact]
+            public void ShouldBeAHttpDelete()
+            {
+                var methodInfo = typeof(QuestionsController).GetMethod(nameof(this.questionsController.Delete));
+
+                var deleteAttribute = methodInfo.GetCustomAttributes(typeof(HttpDeleteAttribute), true)
+                .Cast<HttpDeleteAttribute>()
+                .FirstOrDefault();
+
+                Assert.NotNull(deleteAttribute);
+                Assert.Equal(deleteAttribute.Template, "{id}");
             }
         }
     }

--- a/dotnetcorehack.Test/Controllers/QuestionsControllerTest..cs
+++ b/dotnetcorehack.Test/Controllers/QuestionsControllerTest..cs
@@ -1,0 +1,113 @@
+namespace Dotnetcorehack.Test.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Reflection;
+    using Dotnetcorehack.Controllers;
+    using Dotnetcorehack.Models;
+    using Dotnetcorehack.Repositories;
+    using Dotnetcorehack.Repositories.Interfaces;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    public class QuestionsControllerTest
+    {
+        private Mock<IQuestionRepository> questionRepository;
+        private QuestionsController questionsController;
+        private int expectedId;
+        private Random random;
+
+        public QuestionsControllerTest()
+        {
+            this.random = new Random();
+            this.expectedId = this.random.Next();
+            this.questionRepository = new Mock<IQuestionRepository>();
+
+            this.questionsController = new QuestionsController(this.questionRepository.Object);
+        }
+
+        private string AnyString()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+        public class GetTest : QuestionsControllerTest
+        {
+            [Fact]
+            public void ShouldGetAQuestionByTheId()
+            {
+                var expectedQuestion = new Question();
+                this.questionRepository.Setup(repo => repo.GetQuestionById(this.expectedId)).Returns(expectedQuestion);
+
+                var response = this.questionsController.Get(this.expectedId) as JsonResult;
+
+                Assert.Same(expectedQuestion, response.Value);
+            }
+
+            [Fact]
+            public void ShouldReturnANotFoundResponseWhenTheQuestionDoesNotExist()
+            {
+                var response = this.questionsController.Get(this.expectedId);
+
+                Assert.IsType<NotFoundResult>(response);
+            }
+        }
+
+        public class PostTest : QuestionsControllerTest
+        {
+            [Fact]
+            public void ShouldCreateANewQuestion()
+            {
+                var expectedQuestionToBeCreated = new Question();
+                var expectedQuestionCreated = new Question();
+                expectedQuestionCreated.Id = this.random.Next();
+
+                this.questionRepository.Setup(repo => repo.CreateQuestion(expectedQuestionToBeCreated)).Returns(expectedQuestionCreated);
+
+                var actualResponse = this.questionsController.Post(expectedQuestionToBeCreated) as CreatedResult;
+
+                Assert.Equal(actualResponse.Location, "/questions/" + expectedQuestionCreated.Id);
+                Assert.Same(expectedQuestionCreated, actualResponse.Value);
+            }
+        }
+
+        public class PutTest : QuestionsControllerTest
+        {
+            [Fact]
+            public void ShouldUpdateAQuestion()
+            {
+                var expectedQuestionToBeUpdated = new Question();
+
+                this.questionRepository.Setup(repo => repo.UpdateQuestion(this.expectedId, expectedQuestionToBeUpdated)).Returns(new Question());
+
+                var actualResponse = this.questionsController.Put(this.expectedId, expectedQuestionToBeUpdated);
+
+                Assert.IsType<NoContentResult>(actualResponse);
+            }
+
+            [Fact]
+            public void ShouldReturnNotFoundWhenTheQuestionDoesNotExist()
+            {
+                var actualResponse = this.questionsController.Put(this.expectedId, new Question());
+
+                Assert.IsType<NotFoundResult>(actualResponse);
+            }
+        }
+
+        public class DeleteTest : QuestionsControllerTest
+        {
+            [Fact]
+            public void ShouldCallRepositoryWithId()
+            {
+                var actualResponse = this.questionsController.Delete(this.expectedId);
+
+                this.questionRepository.Verify(repo => repo.DeleteQuestion(this.expectedId), Times.Once);
+
+                Assert.IsType<NoContentResult>(actualResponse);
+            }
+        }
+    }
+}

--- a/dotnetcorehack.Test/Models/AnswerChoiceTest.cs
+++ b/dotnetcorehack.Test/Models/AnswerChoiceTest.cs
@@ -1,0 +1,88 @@
+namespace Dotnetcorehack.Test.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Reflection;
+    using Bogus;
+    using Dotnetcorehack.Models;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    public class AnswerChoiceTest
+    {
+        private AnswerChoice answerChoice;
+        private Faker faker;
+
+        public AnswerChoiceTest()
+        {
+            this.faker = new Faker();
+            this.answerChoice = new AnswerChoice();
+        }
+
+        [Fact]
+        public void ShouldHaveAnIdProperty()
+        {
+            var expectedId = this.faker.Random.Int();
+            this.answerChoice.Id = expectedId;
+
+            Assert.Equal(this.answerChoice.Id, expectedId);
+        }
+
+        [Fact]
+        public void ShouldHaveAQuestionIdProperty()
+        {
+            var expectedQuestionId = this.faker.Random.Int();
+            this.answerChoice.QuestionId = expectedQuestionId;
+
+            Assert.Equal(this.answerChoice.QuestionId, expectedQuestionId);
+        }
+
+        [Fact]
+        public void ShouldHaveTheQuestionIdAsRequired()
+        {
+            var propertyInfo = typeof(AnswerChoice).GetProperty("QuestionId");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+
+        [Fact]
+        public void ShouldHaveALabelProperty()
+        {
+            var expectedLabel = this.faker.Lorem.Text();
+            this.answerChoice.Label = expectedLabel;
+
+            Assert.Equal(this.answerChoice.Label, expectedLabel);
+        }
+
+        [Fact]
+        public void ShouldHaveTheLabelAsRequired()
+        {
+            var propertyInfo = typeof(AnswerChoice).GetProperty("Label");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+
+        [Fact]
+        public void ShouldHaveTheLabelWithAMaxLengthOf255()
+        {
+            var propertyInfo = typeof(AnswerChoice).GetProperty("Label");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(MaxLengthAttribute), true)
+                .Cast<MaxLengthAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+            Assert.Equal(requiredAttribute.Length, 255);
+        }
+    }
+}

--- a/dotnetcorehack.Test/Models/AnswerChoiceTest.cs
+++ b/dotnetcorehack.Test/Models/AnswerChoiceTest.cs
@@ -7,7 +7,6 @@ namespace Dotnetcorehack.Test.Models
     using Bogus;
     using Dotnetcorehack.Models;
     using Microsoft.AspNetCore.Mvc;
-    using Moq;
     using Xunit;
 
     public class AnswerChoiceTest
@@ -42,7 +41,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheQuestionIdAsRequired()
         {
-            var propertyInfo = typeof(AnswerChoice).GetProperty("QuestionId");
+            var propertyInfo = typeof(AnswerChoice).GetProperty(nameof(this.answerChoice.QuestionId));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()
@@ -63,7 +62,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheLabelAsRequired()
         {
-            var propertyInfo = typeof(AnswerChoice).GetProperty("Label");
+            var propertyInfo = typeof(AnswerChoice).GetProperty(nameof(this.answerChoice.Label));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()
@@ -75,7 +74,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheLabelWithAMaxLengthOf255()
         {
-            var propertyInfo = typeof(AnswerChoice).GetProperty("Label");
+            var propertyInfo = typeof(AnswerChoice).GetProperty(nameof(this.answerChoice.Label));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(MaxLengthAttribute), true)
                 .Cast<MaxLengthAttribute>()

--- a/dotnetcorehack.Test/Models/AnswerTest.cs
+++ b/dotnetcorehack.Test/Models/AnswerTest.cs
@@ -7,7 +7,6 @@ namespace Dotnetcorehack.Test.Models
     using Bogus;
     using Dotnetcorehack.Models;
     using Microsoft.AspNetCore.Mvc;
-    using Moq;
     using Xunit;
 
     public class AnswerTest
@@ -51,7 +50,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheQuestionIdAsRequired()
         {
-            var propertyInfo = typeof(AnswerChoice).GetProperty("QuestionId");
+            var propertyInfo = typeof(Answer).GetProperty(nameof(this.answer.QuestionId));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()

--- a/dotnetcorehack.Test/Models/AnswerTest.cs
+++ b/dotnetcorehack.Test/Models/AnswerTest.cs
@@ -1,0 +1,72 @@
+namespace Dotnetcorehack.Test.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Reflection;
+    using Bogus;
+    using Dotnetcorehack.Models;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    public class AnswerTest
+    {
+        private Answer answer;
+        private Faker faker;
+
+        public AnswerTest()
+        {
+            this.faker = new Faker();
+            this.answer = new Answer();
+        }
+
+        [Fact]
+        public void ShouldHaveAnIdProperty()
+        {
+            var expectedId = this.faker.Random.Int();
+            this.answer.Id = expectedId;
+
+            Assert.Equal(this.answer.Id, expectedId);
+        }
+
+        [Fact]
+        public void ShouldHaveAnswerChoiceIdProperty()
+        {
+            var expectedAnswerChoiceId = this.faker.Random.Int();
+            this.answer.AnswerChoiceId = expectedAnswerChoiceId;
+
+            Assert.Equal(this.answer.AnswerChoiceId, expectedAnswerChoiceId);
+        }
+
+        [Fact]
+        public void ShouldHaveQuestionChoiceIdProperty()
+        {
+            var expectedQuestionId = this.faker.Random.Int();
+            this.answer.QuestionId = expectedQuestionId;
+
+            Assert.Equal(this.answer.QuestionId, expectedQuestionId);
+        }
+
+        [Fact]
+        public void ShouldHaveTheQuestionIdAsRequired()
+        {
+            var propertyInfo = typeof(AnswerChoice).GetProperty("QuestionId");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+
+        [Fact]
+        public void ShouldHaveAValueProperty()
+        {
+            var expectedFreeFormText = this.faker.Lorem.Text();
+            this.answer.FreeFormText = expectedFreeFormText;
+
+            Assert.Equal(this.answer.FreeFormText, expectedFreeFormText);
+        }
+    }
+}

--- a/dotnetcorehack.Test/Models/AnswerTest.cs
+++ b/dotnetcorehack.Test/Models/AnswerTest.cs
@@ -59,14 +59,5 @@ namespace Dotnetcorehack.Test.Models
 
             Assert.NotNull(requiredAttribute);
         }
-
-        [Fact]
-        public void ShouldHaveAValueProperty()
-        {
-            var expectedFreeFormText = this.faker.Lorem.Text();
-            this.answer.FreeFormText = expectedFreeFormText;
-
-            Assert.Equal(this.answer.FreeFormText, expectedFreeFormText);
-        }
     }
 }

--- a/dotnetcorehack.Test/Models/QuestionTest.cs
+++ b/dotnetcorehack.Test/Models/QuestionTest.cs
@@ -1,0 +1,96 @@
+namespace Dotnetcorehack.Test.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Reflection;
+    using Bogus;
+    using Dotnetcorehack.Models;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    public class QuestionTest
+    {
+        private Question question;
+        private Faker faker;
+
+        public QuestionTest()
+        {
+            this.faker = new Faker();
+            this.question = new Question();
+        }
+
+        [Fact]
+        public void ShouldHaveAnIdProperty()
+        {
+            var expectedQuestionId = this.faker.Random.Int();
+            this.question.Id = expectedQuestionId;
+
+            Assert.Equal(this.question.Id, expectedQuestionId);
+        }
+
+        [Fact]
+        public void ShouldHaveATextProperty()
+        {
+            var expectedQuestionText = this.faker.Lorem.Text();
+            this.question.Text = expectedQuestionText;
+
+            Assert.Equal(this.question.Text, expectedQuestionText);
+        }
+
+        [Fact]
+        public void ShouldHaveTheTextAsRequired()
+        {
+            var propertyInfo = typeof(Question).GetProperty("Text");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+
+        [Fact]
+        public void ShouldHaveTypeProperty()
+        {
+            var expectedQuestionType = this.faker.Lorem.Text();
+            this.question.Type = expectedQuestionType;
+
+            Assert.Equal(this.question.Type, expectedQuestionType);
+        }
+
+        [Fact]
+        public void ShouldHaveTheTypeAsRequired()
+        {
+            var propertyInfo = typeof(Question).GetProperty("Type");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+
+        [Fact]
+        public void ShouldHaveSurveyIdProperty()
+        {
+            var expectedQuestionType = this.faker.Random.Int();
+            this.question.SurveyId = expectedQuestionType;
+
+            Assert.Equal(this.question.SurveyId, expectedQuestionType);
+        }
+
+        [Fact]
+        public void ShouldHaveTheSurveyIdAsRequired()
+        {
+            var propertyInfo = typeof(Question).GetProperty("SurveyId");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+    }
+}

--- a/dotnetcorehack.Test/Models/QuestionTest.cs
+++ b/dotnetcorehack.Test/Models/QuestionTest.cs
@@ -7,7 +7,6 @@ namespace Dotnetcorehack.Test.Models
     using Bogus;
     using Dotnetcorehack.Models;
     using Microsoft.AspNetCore.Mvc;
-    using Moq;
     using Xunit;
 
     public class QuestionTest
@@ -42,7 +41,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheTextAsRequired()
         {
-            var propertyInfo = typeof(Question).GetProperty("Text");
+            var propertyInfo = typeof(Question).GetProperty(nameof(this.question.Text));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()
@@ -63,7 +62,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheTypeAsRequired()
         {
-            var propertyInfo = typeof(Question).GetProperty("Type");
+            var propertyInfo = typeof(Question).GetProperty(nameof(this.question.Type));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()
@@ -84,7 +83,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheSurveyIdAsRequired()
         {
-            var propertyInfo = typeof(Question).GetProperty("SurveyId");
+            var propertyInfo = typeof(Question).GetProperty(nameof(this.question.SurveyId));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()

--- a/dotnetcorehack.Test/Models/SurveyTest.cs
+++ b/dotnetcorehack.Test/Models/SurveyTest.cs
@@ -7,7 +7,6 @@ namespace Dotnetcorehack.Test.Models
     using Bogus;
     using Dotnetcorehack.Models;
     using Microsoft.AspNetCore.Mvc;
-    using Moq;
     using Xunit;
 
     public class SurveyTest
@@ -42,7 +41,7 @@ namespace Dotnetcorehack.Test.Models
         [Fact]
         public void ShouldHaveTheTitleAsRequired()
         {
-            var propertyInfo = typeof(Survey).GetProperty("Title");
+            var propertyInfo = typeof(Survey).GetProperty(nameof(this.survey.Title));
 
             var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
                 .Cast<RequiredAttribute>()

--- a/dotnetcorehack.Test/Models/SurveyTest.cs
+++ b/dotnetcorehack.Test/Models/SurveyTest.cs
@@ -1,0 +1,54 @@
+namespace Dotnetcorehack.Test.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Reflection;
+    using Bogus;
+    using Dotnetcorehack.Models;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    public class SurveyTest
+    {
+        private Survey survey;
+        private Faker faker;
+
+        public SurveyTest()
+        {
+            this.faker = new Faker();
+            this.survey = new Survey();
+        }
+
+        [Fact]
+        public void ShouldHaveAnIdProperty()
+        {
+            var expectedSurveyId = this.faker.Random.Int();
+            this.survey.Id = expectedSurveyId;
+
+            Assert.Equal(this.survey.Id, expectedSurveyId);
+        }
+
+        [Fact]
+        public void ShouldHaveATitleProperty()
+        {
+            var expectedSurveyText = this.faker.Lorem.Text();
+            this.survey.Title = expectedSurveyText;
+
+            Assert.Equal(this.survey.Title, expectedSurveyText);
+        }
+
+        [Fact]
+        public void ShouldHaveTheTitleAsRequired()
+        {
+            var propertyInfo = typeof(Survey).GetProperty("Title");
+
+            var requiredAttribute = propertyInfo.GetCustomAttributes(typeof(RequiredAttribute), true)
+                .Cast<RequiredAttribute>()
+                .FirstOrDefault();
+
+            Assert.NotNull(requiredAttribute);
+        }
+    }
+}

--- a/dotnetcorehack.Test/dotnetcorehack.Test.csproj
+++ b/dotnetcorehack.Test/dotnetcorehack.Test.csproj
@@ -5,9 +5,7 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\_stylecop\StyleCopRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <Target Name="DisableStyleCop" 
-  	  BeforeTargets="CoreCompile"
-	  Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  <Target Name="DisableStyleCop" BeforeTargets="CoreCompile" Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" />
     </ItemGroup>
@@ -19,6 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="15.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.63" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/dotnetcorehack/Controllers/QuestionsController.cs
+++ b/dotnetcorehack/Controllers/QuestionsController.cs
@@ -5,6 +5,7 @@ namespace Dotnetcorehack.Controllers
     using Microsoft.AspNetCore.Mvc;
     using Newtonsoft.Json;
 
+    [Route("/[controller]")]
     public class QuestionsController : Controller
     {
         private IQuestionRepository questionRepository;
@@ -14,6 +15,7 @@ namespace Dotnetcorehack.Controllers
             this.questionRepository = questionRepository;
         }
 
+        [HttpGet("{id}")]
         public IActionResult Get(int id)
         {
             var question = this.questionRepository.GetQuestionById(id);
@@ -26,6 +28,7 @@ namespace Dotnetcorehack.Controllers
             return this.NotFound();
         }
 
+        [HttpPost]
         public IActionResult Post(Question question)
         {
             var createdQuestion = this.questionRepository.CreateQuestion(question);
@@ -33,6 +36,7 @@ namespace Dotnetcorehack.Controllers
             return this.Created("/questions/" + createdQuestion.Id, createdQuestion);
         }
 
+        [HttpPut("{id}")]
         public IActionResult Put(int id, Question question)
         {
             var updatedQuestion = this.questionRepository.UpdateQuestion(id, question);
@@ -45,6 +49,7 @@ namespace Dotnetcorehack.Controllers
             return this.NoContent();
         }
 
+        [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {
             this.questionRepository.DeleteQuestion(id);

--- a/dotnetcorehack/Controllers/QuestionsController.cs
+++ b/dotnetcorehack/Controllers/QuestionsController.cs
@@ -1,0 +1,55 @@
+namespace Dotnetcorehack.Controllers
+{
+    using Dotnetcorehack.Models;
+    using Dotnetcorehack.Repositories.Interfaces;
+    using Microsoft.AspNetCore.Mvc;
+    using Newtonsoft.Json;
+
+    public class QuestionsController : Controller
+    {
+        private IQuestionRepository questionRepository;
+
+        public QuestionsController(IQuestionRepository questionRepository)
+        {
+            this.questionRepository = questionRepository;
+        }
+
+        public IActionResult Get(int id)
+        {
+            var question = this.questionRepository.GetQuestionById(id);
+
+            if (question != null)
+            {
+                return this.Json(question);
+            }
+
+            return this.NotFound();
+        }
+
+        public IActionResult Post(Question question)
+        {
+            var createdQuestion = this.questionRepository.CreateQuestion(question);
+
+            return this.Created("/questions/" + createdQuestion.Id, createdQuestion);
+        }
+
+        public IActionResult Put(int id, Question question)
+        {
+            var updatedQuestion = this.questionRepository.UpdateQuestion(id, question);
+
+            if (updatedQuestion == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.NoContent();
+        }
+
+        public IActionResult Delete(int id)
+        {
+            this.questionRepository.DeleteQuestion(id);
+
+            return this.NoContent();
+        }
+    }
+}

--- a/dotnetcorehack/Models/Answer.cs
+++ b/dotnetcorehack/Models/Answer.cs
@@ -1,0 +1,16 @@
+namespace Dotnetcorehack.Models
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class Answer
+    {
+        public int Id { get; set; }
+
+        public int AnswerChoiceId { get; set; }
+
+        public string FreeFormText { get; set; }
+
+        [Required]
+        public int QuestionId { get; set; }
+    }
+}

--- a/dotnetcorehack/Models/Answer.cs
+++ b/dotnetcorehack/Models/Answer.cs
@@ -8,8 +8,6 @@ namespace Dotnetcorehack.Models
 
         public int AnswerChoiceId { get; set; }
 
-        public string FreeFormText { get; set; }
-
         [Required]
         public int QuestionId { get; set; }
     }

--- a/dotnetcorehack/Models/AnswerChoice.cs
+++ b/dotnetcorehack/Models/AnswerChoice.cs
@@ -1,0 +1,16 @@
+namespace Dotnetcorehack.Models
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class AnswerChoice
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int QuestionId { get; set; }
+
+        [Required]
+        [MaxLength(255)]
+        public string Label { get; set; }
+    }
+}

--- a/dotnetcorehack/Models/Question.cs
+++ b/dotnetcorehack/Models/Question.cs
@@ -1,6 +1,8 @@
 namespace Dotnetcorehack.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
+    using System.Net.Http;
 
     public class Question
     {
@@ -14,5 +16,10 @@ namespace Dotnetcorehack.Models
 
         [Required]
         public int SurveyId { get; set; }
+
+        public static implicit operator HttpContent(Question v)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/dotnetcorehack/Models/Question.cs
+++ b/dotnetcorehack/Models/Question.cs
@@ -1,0 +1,18 @@
+namespace Dotnetcorehack.Models
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class Question
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Text { get; set; }
+
+        [Required]
+        public string Type { get; set; }
+
+        [Required]
+        public int SurveyId { get; set; }
+    }
+}

--- a/dotnetcorehack/Models/Survey.cs
+++ b/dotnetcorehack/Models/Survey.cs
@@ -1,0 +1,12 @@
+namespace Dotnetcorehack.Models
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class Survey
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Title { get; set; }
+    }
+}

--- a/dotnetcorehack/Repositories/Interfaces/IQuestionRepository.cs
+++ b/dotnetcorehack/Repositories/Interfaces/IQuestionRepository.cs
@@ -1,0 +1,16 @@
+namespace Dotnetcorehack.Repositories.Interfaces
+{
+    using System.Collections.Generic;
+    using Dotnetcorehack.Models;
+
+    public interface IQuestionRepository
+    {
+        Question GetQuestionById(int id);
+
+        Question CreateQuestion(Question question);
+
+        Question UpdateQuestion(int id, Question question);
+
+        void DeleteQuestion(int id);
+    }
+}


### PR DESCRIPTION
Things to improve or think about:
* I should look into using [FluentValidation](https://github.com/JeremySkinner/FluentValidation).  It looks like the de facto validation library and it also works with unobtrusive validation if I do the view in .net
* The model for the answer seems off
* Create a model for the question type rather than storing a string.
* How should I manage the users of this? Creating guids to hand out to people seems like an easy solution.

Current Api

/surveys/{id}
/surveys/{id}/questions
/questions/{id}/answersChoices
/questions{id}/answers
/types

